### PR TITLE
Config lookup and flake8-like entrypoint

### DIFF
--- a/docs/ide.md
+++ b/docs/ide.md
@@ -1,0 +1,7 @@
+# IDE integration
+
+FlakeHell provides `flake8helled` binary that runs `lint` command to make it possible to use FlakeHell instead of Flake8 in any IDE.
+
+1. Open Flake8 plugin settings in your IDE.
+1. Find something like "Executable Path"
+1. Put `flake8helled` in this field.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ It's a [Flake8](https://gitlab.com/pycqa/flake8) wrapper to make it cool.
     config
     formatters
     plugins
+    ide
 
 .. toctree::
     :maxdepth: 1

--- a/flakehell/__init__.py
+++ b/flakehell/__init__.py
@@ -1,8 +1,8 @@
 """Flake8 wrapper to make it nice and configurable
 """
 
-from ._cli import entrypoint
+from ._cli import entrypoint, flake8_entrypoint
 
 
 __version__ = '0.1.4'
-__all__ = ['entrypoint']
+__all__ = ['entrypoint', 'flake8_entrypoint']

--- a/flakehell/_cli.py
+++ b/flakehell/_cli.py
@@ -32,9 +32,22 @@ def main(argv: List[str] = None) -> CommandResult:
 
 
 def entrypoint(argv: List[str] = None) -> NoReturn:
+    """Default entrypoint for CLI (flakehell).
+    """
     if argv is None:
         argv = sys.argv[1:]
     exit_code, msg = main(argv)
+    if msg:
+        print(colored(msg, 'red'))
+    sys.exit(exit_code)
+
+
+def flake8_entrypoint(argv: List[str] = None) -> NoReturn:
+    """Entrypoint with the same behavior as flake8 (flake8helled)
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+    exit_code, msg = main(['lint'] + argv)
     if msg:
         print(colored(msg, 'red'))
     sys.exit(exit_code)

--- a/flakehell/_patched/_app.py
+++ b/flakehell/_patched/_app.py
@@ -1,5 +1,6 @@
+from argparse import ArgumentParser
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional, Tuple
 
 from flake8.main.application import Application
 from flake8.options.aggregator import aggregate_options
@@ -18,16 +19,42 @@ class FlakeHellApplication(Application):
     + register custom formatters
     """
 
-    def get_toml_config(self) -> Dict[str, Any]:
-        path = Path('pyproject.toml')
-        if not path.exists():
-            return dict()
-        return read_config(path)
+    def get_toml_config(self, path: Path = None) -> Dict[str, Any]:
+        if path is not None:
+            return read_config(path)
+        # lookup for config from current dir up to root
+        for dir_path in Path('lol').parents:
+            path = dir_path / 'pyproject.toml'
+            if path.exists():
+                return read_config(path)
+        return dict()
+
+    @staticmethod
+    def extract_toml_config_path(argv: List[str] = None) -> Tuple[Optional[Path], Optional[List[str]]]:
+        if not argv:
+            return None, argv
+        parser = ArgumentParser()
+        parser.add_argument('--config')
+        known, unknown = parser.parse_known_args(argv)
+        if known.config and known.config.endswith('.toml'):
+            return Path(known.config).expanduser(), unknown
+        return None, argv
 
     def parse_configuration_and_cli(self, argv: List[str] = None) -> None:
+        # if passed `--config` with path to TOML-config, we should extract it
+        # before passing into flake8 mechanisms
+        config_path, argv = self.extract_toml_config_path(argv=argv)
+
+        # make default config
         config, _ = self.option_manager.parse_args([])
         config.__dict__.update(DEFAULTS)
-        config.__dict__.update(self.get_toml_config())
+
+        # patch config wtih TOML
+        # If config is explicilty passed, it will be used
+        # If config isn't specified, flakehell will lookup for it
+        config.__dict__.update(self.get_toml_config(config_path))
+
+        # parse CLI options and legacy flake8 configs
         self.options, self.args = aggregate_options(
             manager=self.option_manager,
             config_finder=self.config_finder,
@@ -36,7 +63,7 @@ class FlakeHellApplication(Application):
         )
         super().parse_configuration_and_cli(argv=argv)
 
-    def make_file_checker_manager(self):
+    def make_file_checker_manager(self) -> None:
         self.file_checker_manager = FlakeHellCheckersManager(
             baseline=getattr(self.options, 'baseline', None),
             style_guide=self.guide,
@@ -44,7 +71,7 @@ class FlakeHellApplication(Application):
             checker_plugins=self.check_plugins,
         )
 
-    def make_guide(self):
+    def make_guide(self) -> None:
         """Patched StyleGuide creation just to use FlakeHellStyleGuideManager
         instead of original one.
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ pycodestyle = ["+*"]
 pyflakes = ["+*"]
 flake8-commas = ["+*"]
 flake8-quotes = ["+*"]
-pylint = ["+F*", "+E*", "-E0611", "-E1101"]
+pylint = ["+F*", "+E*", "-E0611", "-E1101", "-E0401"]
 
 # -- DEPHELL -- #
 
@@ -39,7 +39,7 @@ home-page="https://gitlab.com/life4/flakehell"
 requires-python=">=3.5"
 requires=[
     "entrypoints",
-    "flake8",
+    "flake8>=3.7.5",
     "pygments",
     "pylint",
     "termcolor",
@@ -67,6 +67,7 @@ Documentation = "https://flakehell.readthedocs.io/"
 
 [tool.flit.scripts]
 flakehell = "flakehell:entrypoint"
+flake8helled = "flakehell:flake8_entrypoint"
 
 [tool.flit.entrypoints."flake8.extension"]
 pylint = "flakehell.plugins:PyLintChecker"


### PR DESCRIPTION
1. Better config lookup
1. Allow to explicitly specify the path to config
1. Special entry point with `lint` by default
1. Docs for IDE integration

Close #16 
Close #18
Close #19