### PR TITLE
Fix exception thrown when nonexistent filename, especially `-` is passed

### DIFF
--- a/flakehell/_logic/_snapshot.py
+++ b/flakehell/_logic/_snapshot.py
@@ -118,4 +118,3 @@ class Snapshot:
         hasher = md5()
         hasher.update(self.file_path.read_bytes())
         return hasher.hexdigest()
-

--- a/tests/test_flake8helled_stdin.py
+++ b/tests/test_flake8helled_stdin.py
@@ -1,0 +1,24 @@
+import subprocess
+
+
+def test_flake8helled_file():
+    """Baseline behavior, when an actual filename is passed."""
+    cmd = ['python',
+           # This is what flit creates as the 'flake8helled' command
+           '-c', 'import sys; from flakehell import flake8_entrypoint; sys.exit(flake8_entrypoint())',
+           __file__]
+    result = subprocess.run(cmd, capture_output=True)
+    assert result.returncode == 0
+
+
+def test_flake8helled_stdin():
+    """Problematic behavior from issue #44, `-` is passed as filename, together with --stdin-display-name."""
+    source_file = open(__file__, 'r')
+    cmd = ['python',
+           '-c', 'import sys; from flakehell import flake8_entrypoint; sys.exit(flake8_entrypoint())',
+           '--stdin-display-name', __file__,
+           # '-' is not an existing filename, so snapshot cannot create a hexdigest of its content
+           # but otherwise it's fine for flake8 which knows to read stdin instead
+           '-']
+    result = subprocess.run(cmd, stdin=source_file, capture_output=True)
+    assert result.returncode == 0

--- a/tests/test_flake8helled_stdin.py
+++ b/tests/test_flake8helled_stdin.py
@@ -1,12 +1,15 @@
 import subprocess
+import sys
 
 
 def test_flake8helled_file():
     """Baseline behavior, when an actual filename is passed."""
-    cmd = ['python',
-           # This is what flit creates as the 'flake8helled' command
-           '-c', 'import sys; from flakehell import flake8_entrypoint; sys.exit(flake8_entrypoint())',
-           __file__]
+    cmd = [
+        sys.executable,
+        '-c',
+        'import sys; from flakehell import flake8_entrypoint; sys.exit(flake8_entrypoint())',
+        __file__,
+    ]
     result = subprocess.run(cmd)
     assert result.returncode == 0
 
@@ -14,11 +17,15 @@ def test_flake8helled_file():
 def test_flake8helled_stdin():
     """Problematic behavior from issue #44, `-` is passed as filename, together with --stdin-display-name."""
     source_file = open(__file__, 'r')
-    cmd = ['python',
-           '-c', 'import sys; from flakehell import flake8_entrypoint; sys.exit(flake8_entrypoint())',
-           '--stdin-display-name', __file__,
-           # '-' is not an existing filename, so snapshot cannot create a hexdigest of its content
-           # but otherwise it's fine for flake8 which knows to read stdin instead
-           '-']
+    cmd = [
+        sys.executable,
+        '-c',
+        'import sys; from flakehell import flake8_entrypoint; sys.exit(flake8_entrypoint())',
+        '--stdin-display-name',
+        __file__,
+        # '-' is not an existing filename, so snapshot cannot create a hexdigest of its content
+        # but otherwise it's fine for flake8 which knows to read stdin instead
+        '-',
+    ]
     result = subprocess.run(cmd, stdin=source_file)
     assert result.returncode == 0

--- a/tests/test_flake8helled_stdin.py
+++ b/tests/test_flake8helled_stdin.py
@@ -7,7 +7,7 @@ def test_flake8helled_file():
            # This is what flit creates as the 'flake8helled' command
            '-c', 'import sys; from flakehell import flake8_entrypoint; sys.exit(flake8_entrypoint())',
            __file__]
-    result = subprocess.run(cmd, capture_output=True)
+    result = subprocess.run(cmd)
     assert result.returncode == 0
 
 
@@ -20,5 +20,5 @@ def test_flake8helled_stdin():
            # '-' is not an existing filename, so snapshot cannot create a hexdigest of its content
            # but otherwise it's fine for flake8 which knows to read stdin instead
            '-']
-    result = subprocess.run(cmd, stdin=source_file, capture_output=True)
+    result = subprocess.run(cmd, stdin=source_file)
     assert result.returncode == 0


### PR DESCRIPTION
The error is caused by Snapshot class naively reading in file content to
create a md5 digest for the file. This is not possible when `-` is passed,
because a) it is most likely not an existing filename, and b) even if we
were to interpret it as stdin, it isn't seekable (outside of using `os.lseek` when a real file was redirected).

The fix: when calculating digests for a non-existent file, just invent
one from current time and a random value. It will be a new value every
time, ensuring no caching between such stdin invocations.

Fixes #44 