### PR TITLE
Fix and improve baseline

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -51,9 +51,23 @@ Most of default parameters are the same as in Flake8. However, some of them are 
 ```toml
 # make output beautiful
 format='colored'
-# 80 chars aren't enough in 21 century
+# 80 chars limit isn't enough in 21 century
 max_line_length=90
 ```
+
+## Ignored options
+
+FlakeHell doesn't support some flake8 option by design. Flake8 has a long history and over-complicated logic to enable and disable some checks. We make it simple.
+
+| unsupported option    | alternative                   |
+| --------------------- | ----------------------------- |
+| `--extend-exclude`    | use just `exclude`, modify it right in the config if you need. |
+| `--per-file-ignores`  | use `exceptions`              |
+| `--statistics`        | use `--format=stat` instead   |
+| `--ignore`            | use `plugins`                 |
+| `--extend-ignore`     | use `plugins`                 |
+| `--select`            | use `plugins`                 |
+| `--enable-extensions` | use `plugins`                 |
 
 ## Example
 

--- a/flakehell/_constants.py
+++ b/flakehell/_constants.py
@@ -14,6 +14,7 @@ DEFAULTS = dict(
         'pyflakes': ['+*'],
         'pycodestyle': ['+*'],
     },
+    exceptions={},
 )
 
 

--- a/flakehell/_constants.py
+++ b/flakehell/_constants.py
@@ -16,6 +16,15 @@ DEFAULTS = dict(
         'pycodestyle': ['+*'],
     },
     exceptions={},
+
+    # disabled by flakehell but required by flake8
+    extend_exclude=[],
+    ignore=[],
+    extend_ignore=[],
+    select=[],
+    enable_extensions=[],
+    per_file_ignores=[],
+    statistics=False,
 )
 
 

--- a/flakehell/_constants.py
+++ b/flakehell/_constants.py
@@ -8,6 +8,7 @@ VERSION = __version__
 
 # our own modern defaults
 DEFAULTS = dict(
+    baseline=None,
     format='colored',
     max_line_length=90,
     plugins={

--- a/flakehell/_logic/_plugin.py
+++ b/flakehell/_logic/_plugin.py
@@ -53,6 +53,8 @@ def get_plugin_rules(plugin_name: str, plugins: PluginsType) -> List[str]:
     2. Try to find globs that match and select the longest one (nginx-style)
     3. Return empty list if nothing is found.
     """
+    if not plugins:
+        return []
     plugin_name = REX_NAME.sub('-', plugin_name).lower()
     # try to find exact match
     for pattern, rules in plugins.items():
@@ -101,6 +103,8 @@ def check_include(code: str, rules: List[str]) -> bool:
 def get_exceptions(
     path: Union[str, Path], exceptions: Dict[str, PluginsType], root: Path = None,
 ) -> PluginsType:
+    if not exceptions:
+        return dict()
     if isinstance(path, str):
         path = Path(path)
     if root is None:

--- a/flakehell/_patched/_app.py
+++ b/flakehell/_patched/_app.py
@@ -123,6 +123,10 @@ class FlakeHellApplication(Application):
         self.check_plugins.load_plugins()
         self.formatting_plugins.load_plugins()
 
+    def make_formatter(self, *args, **kwargs) -> None:
+        if self.formatter is None:
+            super().make_formatter(*args, **kwargs)
+
     def make_guide(self) -> None:
         """Patched StyleGuide creation just to use FlakeHellStyleGuideManager
         instead of original one.

--- a/flakehell/_patched/_checkers.py
+++ b/flakehell/_patched/_checkers.py
@@ -16,7 +16,8 @@ class FlakeHellCheckersManager(Manager):
     def __init__(self, baseline, **kwargs):
         self.baseline = set()
         if baseline:
-            self.baseline = {line.strip() for line in open(baseline)}
+            with open(baseline) as stream:
+                self.baseline = {line.strip() for line in stream}
         super().__init__(**kwargs)
 
     def make_checkers(self, paths: List[str] = None) -> None:

--- a/flakehell/commands/_baseline.py
+++ b/flakehell/commands/_baseline.py
@@ -15,7 +15,7 @@ def baseline_command(argv) -> CommandResult:
         show_source=False,
     ))
     try:
-        app.run(['--baseline', ''] + argv)
+        app.run(['--baseline', '', '--exit-zero'] + argv)
         app.exit()
     except SystemExit as exc:
         return int(exc.code), ''

--- a/flakehell/commands/_baseline.py
+++ b/flakehell/commands/_baseline.py
@@ -18,4 +18,4 @@ def baseline_command(argv) -> CommandResult:
         app.run(argv)
         app.exit()
     except SystemExit as exc:
-        return exc.code, ''
+        return int(exc.code), ''

--- a/flakehell/commands/_baseline.py
+++ b/flakehell/commands/_baseline.py
@@ -7,7 +7,7 @@ from ..formatters import BaseLineFormatter
 
 
 def baseline_command(argv) -> CommandResult:
-    """Run patched flake8 against the code.
+    """Generate baseline that can be used later to ignore errors.
     """
     app = FlakeHellApplication(program=NAME, version=VERSION)
     app.formatter = BaseLineFormatter(SimpleNamespace(
@@ -15,7 +15,7 @@ def baseline_command(argv) -> CommandResult:
         show_source=False,
     ))
     try:
-        app.run(argv)
+        app.run(['--baseline', ''] + argv)
         app.exit()
     except SystemExit as exc:
         return int(exc.code), ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.flakehell]
-exclude = ["example.py", "setup.py"]
+# exclude = ["example.py", "setup.py"]
 max_line_length = 120
 # show_source = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.flakehell]
-# exclude = ["example.py", "setup.py"]
+exclude = ["example.py", "setup.py"]
 max_line_length = 120
 # show_source = true
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,14 +102,25 @@ def test_exclude(capsys, tmp_path: Path):
 
 def test_baseline(capsys, tmp_path: Path):
     code_path = tmp_path / 'example.py'
-    code_path.write_text('a\nb')
+    code_path.write_text('a\nb\n')
     with chdir(tmp_path):
         result = main(['baseline', str(code_path)])
     assert result == (1, '')
     captured = capsys.readouterr()
     assert captured.err == ''
     hashes = captured.out.strip().split()
-    assert len(hashes) == 3
+    assert len(hashes) == 2
 
     line_path = tmp_path / 'baseline.txt'
-    line_path.write_text(''.join(hashes[:2]))
+    line_path.write_text(hashes[0])
+    with chdir(tmp_path):
+        result = main([
+            'lint',
+            '--baseline', str(line_path),
+            '--format', 'default',
+            str(code_path),
+        ])
+    assert result == (1, '')
+    captured = capsys.readouterr()
+    assert captured.err == ''
+    assert captured.out.strip() == "{}:2:1: F821 undefined name 'b'".format(str(code_path))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,3 +98,18 @@ def test_exclude(capsys, tmp_path: Path):
     ./tests/test_example.py:2:1: F821 undefined name 'a'
     """
     assert captured.out.strip() == dedent(exp).strip()
+
+
+def test_baseline(capsys, tmp_path: Path):
+    code_path = tmp_path / 'example.py'
+    code_path.write_text('a\nb')
+    with chdir(tmp_path):
+        result = main(['baseline', str(code_path)])
+    assert result == (1, '')
+    captured = capsys.readouterr()
+    assert captured.err == ''
+    hashes = captured.out.strip().split()
+    assert len(hashes) == 3
+
+    line_path = tmp_path / 'baseline.txt'
+    line_path.write_text(''.join(hashes[:2]))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,9 +70,18 @@ def test_lint_help(capsys):
     assert result == (0, '')
     captured = capsys.readouterr()
     assert captured.err == ''
+
+    # flake8 options
     assert '-h, --help' in captured.out
     assert '--builtins' in captured.out
     assert '--isort-show-traceback' in captured.out
+
+    # ignored flake8 options
+    assert '--per-file-ignores' not in captured.out
+    assert '--enable-extensions' not in captured.out
+
+    # flakehell options
+    assert '--baseline' in captured.out
 
 
 def test_exclude(capsys, tmp_path: Path):
@@ -105,7 +114,7 @@ def test_baseline(capsys, tmp_path: Path):
     code_path.write_text('a\nb\n')
     with chdir(tmp_path):
         result = main(['baseline', str(code_path)])
-    assert result == (1, '')
+    assert result == (0, '')
     captured = capsys.readouterr()
     assert captured.err == ''
     hashes = captured.out.strip().split()


### PR DESCRIPTION
1. Fix `baseline` command. Close #66
1. Support `--baseline` CLI flag. Close #10
1. Remove options from flake8 CLI that flakehell doesn't support by design.
1. A bit more tests.