### PR TITLE
issues disabled notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ It's a [Flake8](https://gitlab.com/pycqa/flake8) wrapper to make it cool.
 
 ![output example](./assets/grouped.png)
 
+# disabling of issues
+is there any reason to disable the GitHub's issues feature for the project? there doesn't seems to be any notifications regarding this. Could you explain the situation?
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
is there any reason to disable the GitHub's issues feature for the project? there doesn't seems to be any notifications regarding this. Could you please explain the situation? 

also after upgrading `flakehell` to version `0.4.5`, it no longer happens to read `setup.cfg's` `ignore` rules. 

Very sorry to create this PR. I am not sure where to raise it.