### PR TITLE
Faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ It's a [Flake8](https://gitlab.com/pycqa/flake8) wrapper to make it cool.
 + [PyLint](https://github.com/PyCQA/pylint) integration.
 + Allow codes intersection for different plugins.
 
+## Compatibility
+
+FlakeHell supports all flake8 plugins, formatters, and configs. However, FlakeHell has it's own beautiful way to configure enabled plugins and codes. So, options like `--ignore` and `--select` unsupported. You can have flake8 and FlakeHell in one project if you want but enabled plugins should be explicitly specified.
+
 ![output example](./assets/grouped.png)
 
 ## Installation
@@ -110,6 +114,8 @@ dephell venv create --env=pytest
 dephell deps install --env=pytest
 dephell venv run --env=pytest
 ```
+
+Bug-tracker is disabled by-design to shift contributions from words to actions. Please, help us make the project better and don't stalk maintainers in social networks and on the street.
 
 Thank you :heart:
 

--- a/flakehell/_cli.py
+++ b/flakehell/_cli.py
@@ -27,7 +27,7 @@ def main(argv: List[str] = None) -> CommandResult:
     command_name = argv[0]
     if command_name in ('help', '--help', 'commands'):
         show_commands()
-        return 0, ''
+        return ExitCodes.OK, ''
     if command_name not in COMMANDS:
         show_commands()
         return ExitCodes.INVALID_COMMAND, 'Invalid command: {}'.format(command_name)
@@ -53,4 +53,6 @@ def flake8_entrypoint(argv: List[str] = None) -> NoReturn:
     exit_code, msg = main(['lint'] + argv)
     if msg:
         print(colored(msg, 'red'))
+    if isinstance(exit_code, ExitCodes):
+        exit_code = exit_code.value
     sys.exit(exit_code)

--- a/flakehell/_cli.py
+++ b/flakehell/_cli.py
@@ -6,7 +6,7 @@ from typing import List, NoReturn
 from termcolor import colored
 
 # app
-from ._constants import ExitCodes
+from ._constants import ExitCode
 from ._types import CommandResult
 from .commands import COMMANDS
 
@@ -23,14 +23,14 @@ def show_commands():
 def main(argv: List[str] = None) -> CommandResult:
     if not argv:
         show_commands()
-        return ExitCodes.NO_COMMAND, 'No command provided'
+        return ExitCode.NO_COMMAND, 'No command provided'
     command_name = argv[0]
     if command_name in ('help', '--help', 'commands'):
         show_commands()
-        return ExitCodes.OK, ''
+        return ExitCode.OK, ''
     if command_name not in COMMANDS:
         show_commands()
-        return ExitCodes.INVALID_COMMAND, 'Invalid command: {}'.format(command_name)
+        return ExitCode.INVALID_COMMAND, 'Invalid command: {}'.format(command_name)
     return COMMANDS[command_name](argv=argv[1:])
 
 
@@ -53,6 +53,6 @@ def flake8_entrypoint(argv: List[str] = None) -> NoReturn:
     exit_code, msg = main(['lint'] + argv)
     if msg:
         print(colored(msg, 'red'))
-    if isinstance(exit_code, ExitCodes):
+    if isinstance(exit_code, ExitCode):
         exit_code = exit_code.value
     sys.exit(exit_code)

--- a/flakehell/_constants.py
+++ b/flakehell/_constants.py
@@ -35,7 +35,7 @@ DEFAULTS = dict(
 )
 
 
-class ExitCodes(IntEnum):
+class ExitCode(IntEnum):
     OK = 0
 
     # CLI entrypoint

--- a/flakehell/_constants.py
+++ b/flakehell/_constants.py
@@ -36,6 +36,8 @@ DEFAULTS = dict(
 
 
 class ExitCodes(IntEnum):
+    OK = 0
+
     # CLI entrypoint
     NO_COMMAND = 1
     INVALID_COMMAND = 2

--- a/flakehell/_logic/_plugin.py
+++ b/flakehell/_logic/_plugin.py
@@ -31,6 +31,8 @@ def get_plugin_name(plugin: Dict[str, Any]) -> str:
     3. Normalized name that starts with `pep`
     4. `plugin_name`
     """
+    if not plugin:
+        return 'UNKNOWN'
     if plugin['plugin_name'] in ALIASES:
         return ALIASES[plugin['plugin_name']]
 

--- a/flakehell/_logic/_snapshot.py
+++ b/flakehell/_logic/_snapshot.py
@@ -9,9 +9,6 @@ from time import localtime, strftime, time
 from flake8.checker import FileChecker
 from flake8.options.manager import OptionManager
 
-# app
-from ._plugin import get_plugin_name, get_plugin_rules
-
 
 CACHE_PATH = Path.home() / '.cache' / 'flakehell'
 THRESHOLD = 3600 * 24  # 1 day
@@ -39,17 +36,10 @@ class Snapshot:
     @classmethod
     def create(cls, checker: FileChecker, options: OptionManager) -> 'Snapshot':
         hasher = md5()
-        # plugin info
-        for chunk in checker.display_name[:-1]:
-            hasher.update(chunk.encode())
 
         # plugins config
-        plugin_name = get_plugin_name(checker.check)
-        rules = get_plugin_rules(
-            plugin_name=plugin_name,
-            plugins=options.plugins,
-        )
-        hasher.update('|'.join(rules).encode())
+        plugins = json.dumps(options.plugins, sort_keys=True)
+        hasher.update(plugins.encode())
 
         # file path
         file_path = Path(checker.filename).resolve()
@@ -63,6 +53,7 @@ class Snapshot:
     def exists(self) -> bool:
         """Returns True if cache file exists and is actual.
         """
+        return False  #Dropme
         if self._exists is not None:
             return self._exists
 

--- a/flakehell/_patched/_checkers.py
+++ b/flakehell/_patched/_checkers.py
@@ -238,7 +238,7 @@ class FlakeHellFileChecker(FileChecker):
         and provide `plugin_name`.
         """
         if error_code is None:
-            error_code, text = text.split(" ", 1)
+            error_code, text = text.split(' ', 1)
 
         # If we're recovering from a problem in _make_processor, we will not
         # have this attribute.

--- a/flakehell/_patched/_checkers.py
+++ b/flakehell/_patched/_checkers.py
@@ -155,7 +155,13 @@ class FlakeHellCheckersManager(Manager):
             grouped_results = defaultdict(list)
             for result in all_results:
                 if type(result) is not Result:
-                    result = Result(DEFAULT_PLUGIN, *result)
+                    if len(result) == 6:
+                        # cache entry is deserialized into list
+                        result = Result(*result)
+                    else:
+                        # flake8 sets custom error codes in a few places
+                        # where we didn't set `_processed_plugin`
+                        result = Result(DEFAULT_PLUGIN, *result)
                 grouped_results[result.plugin_name].append(result)
 
             # get filename

--- a/flakehell/_patched/_checkers.py
+++ b/flakehell/_patched/_checkers.py
@@ -242,7 +242,7 @@ class FlakeHellFileChecker(FileChecker):
 
         # If we're recovering from a problem in _make_processor, we will not
         # have this attribute.
-        if hasattr(self, "processor"):
+        if hasattr(self, 'processor'):
             line = self.processor.noqa_line_for(line_number)
         else:
             line = None

--- a/flakehell/_patched/_style_guide.py
+++ b/flakehell/_patched/_style_guide.py
@@ -22,7 +22,7 @@ class FlakeHellStyleGuideManager(StyleGuideManager):
         self.style_guides.extend(self.populate_style_guides_with(options))
 
     @lru_cache(maxsize=None)
-    def style_guide_for(self, filename):
+    def style_guide_for(self, filename: str):
         """Patched styleguide finder to give priority to flakehell's stileguides
         """
         guides = sorted(

--- a/flakehell/_types.py
+++ b/flakehell/_types.py
@@ -1,6 +1,6 @@
 # built-in
 from typing import Tuple, Union
-from ._constants import ExitCodes
+from ._constants import ExitCode
 
 
-CommandResult = Tuple[Union[int, ExitCodes], str]
+CommandResult = Tuple[Union[int, ExitCode], str]

--- a/flakehell/_types.py
+++ b/flakehell/_types.py
@@ -1,5 +1,6 @@
 # built-in
-from typing import Tuple
+from typing import Tuple, Union
+from ._constants import ExitCodes
 
 
-CommandResult = Tuple[int, str]
+CommandResult = Tuple[Union[int, ExitCodes], str]

--- a/flakehell/commands/_code.py
+++ b/flakehell/commands/_code.py
@@ -2,7 +2,7 @@
 from termcolor import colored
 
 # app
-from .._constants import NAME, VERSION, ExitCodes
+from .._constants import NAME, VERSION, ExitCode
 from .._logic import color_description, extract, get_installed
 from .._patched import FlakeHellApplication
 from .._types import CommandResult
@@ -12,18 +12,18 @@ def code_command(argv) -> CommandResult:
     """Show plugin name and message for given code.
     """
     if not argv:
-        return ExitCodes.NO_PLUGIN_NAME, 'no plugin name provided'
+        return ExitCode.NO_PLUGIN_NAME, 'no plugin name provided'
     if argv[0] == '--help':
         print(code_command.__doc__)
-        return ExitCodes.OK, ''
+        return ExitCode.OK, ''
     if len(argv) > 1:
-        return ExitCodes.TOO_MANY_ARGS, 'the command accept only one argument'
+        return ExitCode.TOO_MANY_ARGS, 'the command accept only one argument'
     code = argv[0]
 
     app = FlakeHellApplication(program=NAME, version=VERSION)
     plugins = sorted(get_installed(app=app), key=lambda p: p['name'])
     if not plugins:
-        return ExitCodes.NO_PLUGINS_INSTALLED, 'no plugins installed'
+        return ExitCode.NO_PLUGINS_INSTALLED, 'no plugins installed'
 
     messages = []
     checked = set()
@@ -45,7 +45,7 @@ def code_command(argv) -> CommandResult:
         ))
 
     if not messages:
-        return ExitCodes.NO_CODES, 'no messages found'
+        return ExitCode.NO_CODES, 'no messages found'
 
     width = max(len(m['plugin']) for m in messages)
     template = '{plugin} | {message}'
@@ -58,4 +58,4 @@ def code_command(argv) -> CommandResult:
             plugin=message['plugin'].ljust(width),
             message=color_description(message['message']),
         ))
-    return ExitCodes.OK, ''
+    return ExitCode.OK, ''

--- a/flakehell/commands/_code.py
+++ b/flakehell/commands/_code.py
@@ -15,7 +15,7 @@ def code_command(argv) -> CommandResult:
         return ExitCodes.NO_PLUGIN_NAME, 'no plugin name provided'
     if argv[0] == '--help':
         print(code_command.__doc__)
-        return 0, ''
+        return ExitCodes.OK, ''
     if len(argv) > 1:
         return ExitCodes.TOO_MANY_ARGS, 'the command accept only one argument'
     code = argv[0]
@@ -58,4 +58,4 @@ def code_command(argv) -> CommandResult:
             plugin=message['plugin'].ljust(width),
             message=color_description(message['message']),
         ))
-    return 0, ''
+    return ExitCodes.OK, ''

--- a/flakehell/commands/_codes.py
+++ b/flakehell/commands/_codes.py
@@ -19,7 +19,7 @@ def codes_command(argv) -> CommandResult:
         return ExitCodes.NO_PLUGIN_NAME, 'no plugin name provided'
     if argv[0] == '--help':
         print(codes_command.__doc__)
-        return 0, ''
+        return ExitCodes.OK, ''
     if len(argv) > 1:
         return ExitCodes.TOO_MANY_ARGS, 'the command accept only one argument'
 
@@ -36,4 +36,4 @@ def codes_command(argv) -> CommandResult:
             code=color_code(code.ljust(width)),
             info=color_description(info),
         ))
-    return 0, ''
+    return ExitCodes.OK, ''

--- a/flakehell/commands/_codes.py
+++ b/flakehell/commands/_codes.py
@@ -2,7 +2,7 @@
 import re
 
 # app
-from .._constants import ExitCodes
+from .._constants import ExitCode
 from .._logic import color_code, color_description, extract
 from .._types import CommandResult
 
@@ -16,19 +16,19 @@ def codes_command(argv) -> CommandResult:
     """Show available codes and messages for given plugin.
     """
     if not argv:
-        return ExitCodes.NO_PLUGIN_NAME, 'no plugin name provided'
+        return ExitCode.NO_PLUGIN_NAME, 'no plugin name provided'
     if argv[0] == '--help':
         print(codes_command.__doc__)
-        return ExitCodes.OK, ''
+        return ExitCode.OK, ''
     if len(argv) > 1:
-        return ExitCodes.TOO_MANY_ARGS, 'the command accept only one argument'
+        return ExitCode.TOO_MANY_ARGS, 'the command accept only one argument'
 
     try:
         codes = extract(argv[0])
     except ImportError as e:
-        return ExitCodes.IMPORT_ERROR, 'cannot import module: {}'.format(e.args[0])
+        return ExitCode.IMPORT_ERROR, 'cannot import module: {}'.format(e.args[0])
     if not codes:
-        return ExitCodes.NO_CODES, 'no codes found'
+        return ExitCode.NO_CODES, 'no codes found'
 
     width = max(len(code) for code in codes)
     for code, info in sorted(codes.items()):
@@ -36,4 +36,4 @@ def codes_command(argv) -> CommandResult:
             code=color_code(code.ljust(width)),
             info=color_description(info),
         ))
-    return ExitCodes.OK, ''
+    return ExitCode.OK, ''

--- a/flakehell/commands/_missed.py
+++ b/flakehell/commands/_missed.py
@@ -10,7 +10,7 @@ def missed_command(argv) -> CommandResult:
     """
     if argv and argv[0] == '--help':
         print(missed_command.__doc__)
-        return 0, ''
+        return ExitCodes.OK, ''
     if argv:
         return ExitCodes.TOO_MANY_ARGS, 'the command does not accept arguments'
 

--- a/flakehell/commands/_missed.py
+++ b/flakehell/commands/_missed.py
@@ -1,5 +1,5 @@
 # app
-from .._constants import NAME, VERSION, ExitCodes
+from .._constants import NAME, VERSION, ExitCode
 from .._logic import get_installed, get_plugin_rules
 from .._patched import FlakeHellApplication
 from .._types import CommandResult
@@ -10,14 +10,14 @@ def missed_command(argv) -> CommandResult:
     """
     if argv and argv[0] == '--help':
         print(missed_command.__doc__)
-        return ExitCodes.OK, ''
+        return ExitCode.OK, ''
     if argv:
-        return ExitCodes.TOO_MANY_ARGS, 'the command does not accept arguments'
+        return ExitCode.TOO_MANY_ARGS, 'the command does not accept arguments'
 
     app = FlakeHellApplication(program=NAME, version=VERSION)
     installed_plugins = sorted(get_installed(app=app), key=lambda p: p['name'])
     if not installed_plugins:
-        return ExitCodes.NO_PLUGINS_INSTALLED, 'no plugins installed'
+        return ExitCode.NO_PLUGINS_INSTALLED, 'no plugins installed'
 
     count = 0
     for pattern in app.options.plugins:

--- a/flakehell/commands/_plugins.py
+++ b/flakehell/commands/_plugins.py
@@ -2,7 +2,7 @@
 from termcolor import colored
 
 # app
-from .._constants import NAME, VERSION, ExitCodes
+from .._constants import NAME, VERSION, ExitCode
 from .._logic import get_installed, get_plugin_rules
 from .._patched import FlakeHellApplication
 from .._types import CommandResult
@@ -14,7 +14,7 @@ def plugins_command(argv) -> CommandResult:
     app = FlakeHellApplication(program=NAME, version=VERSION)
     plugins = sorted(get_installed(app=app), key=lambda p: p['name'])
     if not plugins:
-        return ExitCodes.NO_PLUGINS_INSTALLED, 'no plugins installed'
+        return ExitCode.NO_PLUGINS_INSTALLED, 'no plugins installed'
 
     name_width = max(len(p['name']) for p in plugins)
     version_width = max(8, max(len(p['version']) for p in plugins))
@@ -52,4 +52,4 @@ def plugins_command(argv) -> CommandResult:
             codes=', '.join(plugin['codes']).ljust(codes_width),
             rules=', '.join(colored_rules),
         ))
-    return ExitCodes.OK, ''
+    return ExitCode.OK, ''

--- a/flakehell/commands/_plugins.py
+++ b/flakehell/commands/_plugins.py
@@ -52,4 +52,4 @@ def plugins_command(argv) -> CommandResult:
             codes=', '.join(plugin['codes']).ljust(codes_width),
             rules=', '.join(colored_rules),
         ))
-    return 0, ''
+    return ExitCodes.OK, ''

--- a/flakehell/commands/_version.py
+++ b/flakehell/commands/_version.py
@@ -3,7 +3,7 @@ from flake8 import __version__ as flake8_version
 from termcolor import colored
 
 # app
-from .._constants import ExitCodes
+from .._constants import ExitCode
 from .._types import CommandResult
 from .._version import __version__ as flakehell_version
 
@@ -14,4 +14,4 @@ def version_command(argv) -> CommandResult:
     print('FlakeHell', colored(flakehell_version, 'green'))
     print('Flake8   ', colored(flake8_version, 'green'))
     print('For plugins versions use', colored('flakehell plugins', 'green'))
-    return ExitCodes.OK, ''
+    return ExitCode.OK, ''

--- a/flakehell/commands/_version.py
+++ b/flakehell/commands/_version.py
@@ -3,6 +3,7 @@ from flake8 import __version__ as flake8_version
 from termcolor import colored
 
 # app
+from .._constants import ExitCodes
 from .._types import CommandResult
 from .._version import __version__ as flakehell_version
 
@@ -13,4 +14,4 @@ def version_command(argv) -> CommandResult:
     print('FlakeHell', colored(flakehell_version, 'green'))
     print('Flake8   ', colored(flake8_version, 'green'))
     print('For plugins versions use', colored('flakehell plugins', 'green'))
-    return 0, ''
+    return ExitCodes.OK, ''

--- a/flakehell/commands/_yesqa.py
+++ b/flakehell/commands/_yesqa.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 
 # app
-from .._constants import ExitCodes
+from .._constants import ExitCode
 from .._logic import YesQA
 from .._types import CommandResult
 
@@ -23,10 +23,10 @@ def yesqa_command(argv) -> CommandResult:
     """Remove bare and unused noqa comments.
     """
     if not argv:
-        return ExitCodes.NOT_ENOUGH_ARGS, 'no file path provided'
+        return ExitCode.NOT_ENOUGH_ARGS, 'no file path provided'
     if argv[0] == '--help':
         print(yesqa_command.__doc__)
-        return ExitCodes.OK, ''
+        return ExitCode.OK, ''
 
     paths = get_paths(Path(fname) for fname in argv)
     fixer = YesQA()
@@ -34,4 +34,4 @@ def yesqa_command(argv) -> CommandResult:
         modified = fixer(path=path)
         if modified:
             print(str(path))
-    return ExitCodes.OK, ''
+    return ExitCode.OK, ''

--- a/flakehell/commands/_yesqa.py
+++ b/flakehell/commands/_yesqa.py
@@ -26,7 +26,7 @@ def yesqa_command(argv) -> CommandResult:
         return ExitCodes.NOT_ENOUGH_ARGS, 'no file path provided'
     if argv[0] == '--help':
         print(yesqa_command.__doc__)
-        return 0, ''
+        return ExitCodes.OK, ''
 
     paths = get_paths(Path(fname) for fname in argv)
     fixer = YesQA()
@@ -34,4 +34,4 @@ def yesqa_command(argv) -> CommandResult:
         modified = fixer(path=path)
         if modified:
             print(str(path))
-    return 0, ''
+    return ExitCodes.OK, ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.flakehell]
-exclude = ["example.py", "setup.py"]
+# exclude = ["example.py", "setup.py"]
 max_line_length = 120
 # show_source = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.flakehell]
-# exclude = ["example.py", "setup.py"]
+exclude = ["example.py", "setup.py"]
 max_line_length = 120
 # show_source = true
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,10 +176,8 @@ def test_ignore_file_by_top_level_noqa(capsys, tmp_path: Path):
     assert result == (1, '')
     captured = capsys.readouterr()
     assert captured.err == ''
-    exp = """
-    ./example1.py:1:1: F401 'sys' imported but unused
-    """
-    assert captured.out.strip() == dedent(exp).strip()
+    exp = "./example1.py:1:1: F401 'sys' imported but unused"
+    assert captured.out.strip() == exp
 
 
 def test_exclude_file(capsys, tmp_path: Path):

--- a/tests/test_patched/test_checkers.py
+++ b/tests/test_patched/test_checkers.py
@@ -7,14 +7,15 @@ from flakehell._patched._checkers import FlakeHellFileChecker
 
 def test_nonexistent_file():
     """Verify that checking non-existent file results in an error."""
+    plugin = {
+        'plugin_name': 'flake8-example',
+        'name': 'something',
+        'plugin': FlakeHellFileChecker,
+    }
+    checks = dict(ast_plugins=[plugin], logical_line_plugins=[], physical_line_plugins=[])
     c = FlakeHellFileChecker(
         filename='foobar.py',
-        check_type='ast',
-        check={
-            'plugin_name': 'flake8-example',
-            'name': 'something',
-            'plugin': FlakeHellFileChecker,
-        },
+        checks=checks,
         options=None,
     )
 
@@ -22,7 +23,7 @@ def test_nonexistent_file():
     assert not c.should_process
     assert len(c.results) == 1
     error = c.results[0]
-    assert error[0] == 'E902'
+    assert error.error_code == 'E902'
 
 
 def test_catches_exception_on_invalid_syntax(tmp_path):
@@ -36,15 +37,15 @@ def test_catches_exception_on_invalid_syntax(tmp_path):
     }
     options = mock.MagicMock()
     options.safe = False
+    checks = dict(ast_plugins=[plugin], logical_line_plugins=[], physical_line_plugins=[])
     fchecker = FlakeHellFileChecker(
         filename=str(code_path),
-        check_type='ast',
-        check=plugin,
+        checks=checks,
         options=options,
     )
     assert fchecker.should_process is True
     assert fchecker.processor is not None
     fchecker.run_checks()
     assert len(fchecker.results) == 1
-    assert fchecker.results[0][0] == 'E999'
-    assert fchecker.results[0][3] == 'SyntaxError: invalid syntax'
+    assert fchecker.results[0].error_code == 'E999'
+    assert fchecker.results[0].text == 'SyntaxError: invalid syntax'


### PR DESCRIPTION
1. Make one checker per-file. Fixes #81 
1. Do not store hash for stdin.
1. Annotate more types.
1. Make exit codes more diverse.
1. Add compatibility note into README right after features.