### PR TITLE
Allow flakehell to be installed from the source alone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,3 +153,7 @@ dev = [
     "pytest",
     "isort[pyproject]",
 ]
+
+[build-system]
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"


### PR DESCRIPTION
See https://flit.readthedocs.io/en/latest/pyproject_toml.html#build-system-section

This will allow `flakehell` installable from just the source. E.g. `pip install git+git+https://github.com/life4/flakehell`