### PR TITLE
Correct file matching settings for pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,6 @@
     description: '`flakehell` is a `flake8` wrapper to make a nice, legacy-friendly, configurable command-line utility for enforcing style consistency across Python projects.'
     entry: flakehell lint
     language: python
-    types: [python, markdown, rst, jupyter, yaml]
+    types: [file, text]
+    files: \.(ipynb|md|py|rst|yaml|yml)$
     require_serial: true


### PR DESCRIPTION
I specced out a wrong pattern; the `types` list is used as a mandatory subset for each file matched. Since no file will ever have all 5 tags listed, no file is ever checked.

By setting the `types` spec to `[file, text]`, any links, directories and binary files are excluded, and it's the `files` regex that determines what of these text files is actually interesting for flakehell to handle.