### PR TITLE
Restrict isort to a version before 5.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,5 +151,5 @@ dev = [
     "wemake-python-styleguide",
 
     "pytest",
-    "isort[pyproject]",
+    "isort[pyproject] < 5",
 ]


### PR DESCRIPTION
flake8-isort has [pinned itself to isort 4.x](https://github.com/gforcada/flake8-isort/issues/88), and [so has pylint](https://github.com/PyCQA/pylint/blob/master/pylint/__pkginfo__.py#L41), but dephell hits some kind of infinite recursion trying to resolve this between those two packages, and the unqualified `isort[pyproject]` dependency in pyproject.toml.

By restricting isort, dephell can complete installing.