### PR TITLE
Baseline hashes not use forward-slash on all platforms

### DIFF
--- a/flakehell/_logic/_baseline.py
+++ b/flakehell/_logic/_baseline.py
@@ -1,10 +1,11 @@
 # built-in
 from hashlib import md5
+from pathlib import Path
 
 
 def make_baseline(path: str, context: str, code: str, line: int) -> str:
     digest = md5()
-    digest.update(path.lstrip('./').encode())
+    digest.update(Path(path).as_posix().lstrip('./').encode())
     digest.update((context or str(line)).strip().encode())
     digest.update(code.encode())
     return digest.hexdigest()

--- a/flakehell/formatters/_baseline.py
+++ b/flakehell/formatters/_baseline.py
@@ -8,8 +8,6 @@ from .._logic import make_baseline
 class BaseLineFormatter(BaseFormatter):
     def format(self, error):
         filename = error.filename
-        if filename.startswith('./'):
-            filename = filename[2:]
         return make_baseline(
             path=filename,
             code=error.code,

--- a/flakehell/formatters/_gitlab.py
+++ b/flakehell/formatters/_gitlab.py
@@ -26,8 +26,6 @@ class GitlabFormatter(BaseFormatter):
 
     def format(self, error):
         filename = error.filename
-        if filename.startswith('./'):
-            filename = filename[2:]
         digest = make_baseline(
             path=filename,
             code=error.code,


### PR DESCRIPTION
This will allow baseline files to be generated on any platform to be consumed on any platform.

NOTE: Unfortunately, this will break existing baseline files generated on machines that use back slashes.