### PR TITLE
Fix --config handling and allow --append-config

### DIFF
--- a/flakehell/_logic/_discover.py
+++ b/flakehell/_logic/_discover.py
@@ -22,11 +22,11 @@ ALIASES = {
 }
 
 
-def get_installed(app) -> Iterator[Dict[str, Any]]:
+def get_installed(app, argv=[]) -> Iterator[Dict[str, Any]]:
     plugins_codes = defaultdict(list)
     versions = dict()
 
-    app.initialize([])
+    app.initialize(argv)
     codes: Iterable[str]
 
     for check_type in ('ast_plugins', 'logical_line_plugins', 'physical_line_plugins'):

--- a/flakehell/commands/_code.py
+++ b/flakehell/commands/_code.py
@@ -13,18 +13,16 @@ def code_command(argv) -> CommandResult:
     """
     if not argv:
         return ExitCode.NO_PLUGIN_NAME, 'no plugin name provided'
-    if argv[0] == '--help':
+    if '--help' in argv:
         print(code_command.__doc__)
         return ExitCode.OK, ''
-    if len(argv) > 1:
-        return ExitCode.TOO_MANY_ARGS, 'the command accept only one argument'
-    code = argv[0]
 
     app = FlakeHellApplication(program=NAME, version=VERSION)
-    plugins = sorted(get_installed(app=app), key=lambda p: p['name'])
+    plugins = sorted(get_installed(app=app, argv=argv), key=lambda p: p['name'])
     if not plugins:
         return ExitCode.NO_PLUGINS_INSTALLED, 'no plugins installed'
 
+    code = app.args[0]
     messages = []
     checked = set()
     for plugin in plugins:

--- a/flakehell/commands/_missed.py
+++ b/flakehell/commands/_missed.py
@@ -11,11 +11,9 @@ def missed_command(argv) -> CommandResult:
     if argv and argv[0] == '--help':
         print(missed_command.__doc__)
         return ExitCode.OK, ''
-    if argv:
-        return ExitCode.TOO_MANY_ARGS, 'the command does not accept arguments'
 
     app = FlakeHellApplication(program=NAME, version=VERSION)
-    installed_plugins = sorted(get_installed(app=app), key=lambda p: p['name'])
+    installed_plugins = sorted(get_installed(app=app, argv=argv), key=lambda p: p['name'])
     if not installed_plugins:
         return ExitCode.NO_PLUGINS_INSTALLED, 'no plugins installed'
 

--- a/flakehell/commands/_plugins.py
+++ b/flakehell/commands/_plugins.py
@@ -12,7 +12,7 @@ def plugins_command(argv) -> CommandResult:
     """Show all installed plugins, their codes prefix, and matched rules from config.
     """
     app = FlakeHellApplication(program=NAME, version=VERSION)
-    plugins = sorted(get_installed(app=app), key=lambda p: p['name'])
+    plugins = sorted(get_installed(app=app, argv=argv), key=lambda p: p['name'])
     if not plugins:
         return ExitCode.NO_PLUGINS_INSTALLED, 'no plugins installed'
 


### PR DESCRIPTION
From my testing, passing --config ./file.toml wasn't being handled correctly.
Debugging it, it looks like parse_preliminary_options in flake8 strips out these options, so by the time we get to it in parse_configuration_and_cli they are nowhere to be found in argv.