### PR TITLE
Fix gitlab formatter with --output_file option

### DIFF
--- a/flakehell/formatters/_gitlab.py
+++ b/flakehell/formatters/_gitlab.py
@@ -12,12 +12,14 @@ class GitlabFormatter(BaseFormatter):
     error_format = '{code} {text}'
 
     def start(self):
+        super().start()
         self._write('[')
         self.newline = ''
         self._first_line = True
 
     def stop(self):
         self._write('\n]\n')
+        super().stop()
 
     def handle(self, error):
         # redefined to never output source


### PR DESCRIPTION
`BaseFormatter.start ` and `BaseFormatter.stop` were shadowed and never called, therefore `BaseFormatter.output_fd` wasn't set and formatter ignored `--output_file` option