### PR TITLE
Color fix for windows

### DIFF
--- a/flakehell/_cli.py
+++ b/flakehell/_cli.py
@@ -4,15 +4,16 @@ from typing import List, NoReturn
 
 # external
 from termcolor import colored
-
-# use colorama to make termcolor work on Windows
 import colorama
-colorama.init()
 
 # app
 from ._constants import ExitCode
 from ._types import CommandResult
 from .commands import COMMANDS
+
+
+# use colorama to make termcolor work on Windows
+colorama.init()
 
 
 def show_commands():

--- a/flakehell/_cli.py
+++ b/flakehell/_cli.py
@@ -5,6 +5,10 @@ from typing import List, NoReturn
 # external
 from termcolor import colored
 
+# use colorama to make termcolor work on Windows
+import colorama
+colorama.init()
+
 # app
 from ._constants import ExitCode
 from ._types import CommandResult

--- a/flakehell/_cli.py
+++ b/flakehell/_cli.py
@@ -1,5 +1,6 @@
 # built-in
 import sys
+import os
 from typing import List, NoReturn
 
 # external
@@ -12,8 +13,9 @@ from ._types import CommandResult
 from .commands import COMMANDS
 
 
-# use colorama to make termcolor work on Windows
-colorama.init()
+if os.name == 'nt':
+    # use colorama to make termcolor work on Windows
+    colorama.init()
 
 
 def show_commands():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ requires=[
     "termcolor",
     "toml",
     "urllib3",
+    "colorama",
 ]
 description-file="README.md"
 classifiers=[


### PR DESCRIPTION
On Windows, the colored output of flakehell is not displayed properly. To solve this, colorama.init() must be called.