### PR TITLE
Fix ValueError: '/dev/null' does not start with '{project_path}'

### DIFF
--- a/flakehell/_logic/_plugin.py
+++ b/flakehell/_logic/_plugin.py
@@ -122,7 +122,6 @@ def get_exceptions(
         return dict()
     if isinstance(path, str):
         path = Path(path)
-    
     if root is None:
         root = Path().resolve()
     try:

--- a/flakehell/_logic/_plugin.py
+++ b/flakehell/_logic/_plugin.py
@@ -127,7 +127,7 @@ def get_exceptions(
     try:
         path = path.resolve().relative_to(root).as_posix()
     except ValueError:
-        path = Path().resolve()
+        path = path.resolve().as_posix()
     exceptions = sorted(
         exceptions.items(),
         key=lambda item: len(item[0]),

--- a/flakehell/_logic/_plugin.py
+++ b/flakehell/_logic/_plugin.py
@@ -127,7 +127,8 @@ def get_exceptions(
     try:
         path = path.resolve().relative_to(root).as_posix()
     except ValueError:
-        path = path.resolve().as_posix()
+        # path is not in the project root
+        return dict()
     exceptions = sorted(
         exceptions.items(),
         key=lambda item: len(item[0]),

--- a/flakehell/_logic/_plugin.py
+++ b/flakehell/_logic/_plugin.py
@@ -122,9 +122,13 @@ def get_exceptions(
         return dict()
     if isinstance(path, str):
         path = Path(path)
+    
     if root is None:
         root = Path().resolve()
-    path = path.resolve().relative_to(root).as_posix()
+    try:
+        path = path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        path = Path().resolve()
     exceptions = sorted(
         exceptions.items(),
         key=lambda item: len(item[0]),


### PR DESCRIPTION
When using `git diff | flakehell lint --diff`, deletions are marked as `+++ /dev/null` resulting in 

```py
  File ".../python3.6/site-packages/flakehell/_logic/_plugin.py", line 127, in get_exceptions
    path = path.resolve().relative_to(root).as_posix()
  File ".../python3.6/pathlib.py", line 874, in relative_to
    .format(str(self), str(formatted)))
ValueError: '/dev/null' does not start with '{project_dir}'
```