### PR TITLE
Use FLAKEHELL_CACHE environment variable

### DIFF
--- a/flakehell/_logic/_snapshot.py
+++ b/flakehell/_logic/_snapshot.py
@@ -1,5 +1,6 @@
 # built-in
 import json
+import os
 from hashlib import md5
 from pathlib import Path
 from time import time
@@ -10,7 +11,7 @@ from flake8.checker import FileChecker
 from flake8.options.manager import OptionManager
 
 
-CACHE_PATH = Path.home() / '.cache' / 'flakehell'
+CACHE_PATH = Path(os.environ.get('FLAKEHELL_CACHE', Path.home() / '.cache' / 'flakehell'))
 THRESHOLD = 3600 * 24  # 1 day
 
 


### PR DESCRIPTION
A PermissionError can be raised when trying to create the cache directory. We allow the user to change the cache path with the FLAKEHELL_CACHE environment variable to work around this issue.

Replaces #101.
