### PR TITLE
Update message output

### DIFF
--- a/flakehell/_logic/_colors.py
+++ b/flakehell/_logic/_colors.py
@@ -37,7 +37,6 @@ COLORS = dict(
     F='red',
     WPS='magenta',
 )
-REX_CODE = re.compile(r'([A-Z]+)([0-9]+)')
 REX_TEXT = re.compile('[A-Z]+')
 REX_NUMBER = re.compile('( [0-9]+)')
 REX_PLACEHOLDER = re.compile(r'(\{[a-z0-9]+\}|\%[a-z])')
@@ -64,7 +63,7 @@ def color_code(code: str) -> str:
     color = 'blue'
     if match:
         color = COLORS.get(match.group(), color)
-    return REX_CODE.sub(colored(r'\1', color) + colored(r'\2', 'cyan'), code)
+    return colored(code, color)
 
 
 def color_description(text: str) -> str:

--- a/flakehell/plugins/_pylint.py
+++ b/flakehell/plugins/_pylint.py
@@ -32,7 +32,7 @@ class Reporter(BaseReporter):
         self.errors.append(dict(
             row=msg.line,
             col=msg.column,
-            text='{} {}'.format(msg.msg_id, msg.msg or ''),
+            text='{} {} ({})'.format(msg.msg_id, msg.msg or '', msg.symbol),
             code=msg.msg_id,
         ))
 


### PR DESCRIPTION
- Adding the pylint symbol (verbal error code) makes disabling certain errors a bit easier.
- Printing error codes in only one color makes them a bit more readable and from my experience, there is no real need to make the number stand out.

The pylint issue is more important for me.  If you have any objections against the other change, I can revert it. :)